### PR TITLE
Fix crash when compiling on the debug configuration with MSVC

### DIFF
--- a/textselect.cpp
+++ b/textselect.cpp
@@ -48,8 +48,11 @@ static float substringSizeX(std::string_view s, size_t start, size_t length = st
     if (length == std::string_view::npos) stringEnd = s.end();
     else utf8::unchecked::advance(stringEnd, std::min(utf8Length(s), length));
 
+    // Dereferencing std::string_view::end() may be undefined behavior in some compilers,
+    // because of that, we need to get the pointer value manually if stringEnd == s.end().
+    const char* endPtr = stringEnd == s.end() ? s.data() + s.size() : &*stringEnd;
     // Calculate text size between start and end
-    return ImGui::CalcTextSize(&*stringStart, &*stringEnd).x;
+    return ImGui::CalcTextSize(&*stringStart, endPtr).x;
 }
 
 // Gets the index of the character the mouse cursor is over.


### PR DESCRIPTION
MSVC does not allow `std::string_view::end()` to be dereferenced and will crash if you try to do this on the debug configuration as can be seen here: https://github.com/microsoft/STL/blob/ff0cff1ad6de63525d0a6646b49cc10667446682/stl/inc/xstring#L908.
Manually getting the pointer to the end of the string fixes that.