### PR TITLE
add c++17 compatibility

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -20,7 +20,7 @@ Released under the MIT License.
 
 - [Dear ImGui](https://github.com/ocornut/imgui)
 - [utfcpp](https://github.com/nemtrif/utfcpp) (For UTF-8 handling)
-- C++20 (For `std::midpoint`, though this can easily be patched to support C++17)
+- C++17 or later
 
 ## Integration
 
@@ -95,7 +95,7 @@ ImGui::Begin("Text selection");
 ImGui::BeginChild("text", {}, 0, ImGuiWindowFlags_NoMove);
 
 // Display each line
-for (const auto& line : lines) ImGui::TextUnformatted(line.c_str());
+for (const auto& line : lines) ImGui::TextUnformatted(line.data());
 
 // Update TextSelect instance (all text selection is handled in this method)
 textSelect.update();

--- a/textselect.cpp
+++ b/textselect.cpp
@@ -16,7 +16,7 @@
 
 #include "textselect.hpp"
 
-// Calculates the midpoint between two numbers at compile time
+// Calculates the midpoint between two numbers
 template<typename T>
 constexpr T midpoint(T a, T b) {
     return a + (b - a) / 2;

--- a/textselect.cpp
+++ b/textselect.cpp
@@ -23,7 +23,7 @@ constexpr T midpoint(T a, T b) {
 }
 
 // Checks if a string view ends with the specified char suffix
-bool ends_with(std::string_view str, char suffix) {
+bool endsWith(std::string_view str, char suffix) {
     return !str.empty() && str.back() == suffix;
 }
 

--- a/textselect.cpp
+++ b/textselect.cpp
@@ -16,6 +16,17 @@
 
 #include "textselect.hpp"
 
+// Calculates the midpoint between two numbers at compile time
+template<typename T>
+constexpr T midpoint(T a, T b) {
+    return a + (b - a) / 2;
+}
+
+// Checks if a string view ends with the specified char suffix
+bool ends_with(std::string_view str, char suffix) {
+    return !str.empty() && str.back() == suffix;
+}
+
 // Simple word boundary detection, accounts for Latin Unicode blocks only.
 static bool isBoundary(char32_t c) {
     using Range = std::array<char32_t, 2>;
@@ -66,7 +77,7 @@ static std::size_t getCharIndex(std::string_view s, float cursorPosX, std::size_
     if (end < start) return utf8Length(s);
 
     // Midpoint of given string range
-    std::size_t midIdx = std::midpoint(start, end);
+    std::size_t midIdx = midpoint(start, end);
 
     // Display width of the entire string up to the midpoint, gives the x-position where the (midIdx + 1)th char starts
     float widthToMid = substringSizeX(s, 0, midIdx + 1);
@@ -264,7 +275,7 @@ void TextSelect::copy() const {
         selectedText += lineToAdd;
 
         // If lines before the last line don't already end with newlines, add them in
-        if (!lineToAdd.ends_with('\n') && i < endY) selectedText += '\n';
+        if (!ends_with(lineToAdd, '\n') && i < endY) selectedText += '\n';
     }
 
     ImGui::SetClipboardText(selectedText.c_str());


### PR DESCRIPTION
Added native C++17 compatibility:

- Created templated utility function replacing `std::midpoint`
- Created simple utility function replacing `ends_with` method of `std::string_view` (introduced in C++20)
- Updated readme example to use `data()` method on string view instead of `c_string()` (introduced later aswell) 