### PR TITLE
Keep selecting when cursor is outside window

### DIFF
--- a/textselect.cpp
+++ b/textselect.cpp
@@ -297,8 +297,18 @@ void TextSelect::update() {
     if (hovered) ImGui::SetMouseCursor(ImGuiMouseCursor_TextInput);
 
     // Handle mouse events
+    if (ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
+        if (hovered) {
+            shouldHandleMouseDown = true;
+        }
+    }
+
+    if (ImGui::IsMouseReleased(ImGuiMouseButton_Left)) {
+        shouldHandleMouseDown = false;
+    }
+
     if (ImGui::IsMouseDown(ImGuiMouseButton_Left)) {
-        handleMouseDown(cursorPosStart);
+        if (shouldHandleMouseDown) handleMouseDown(cursorPosStart);
         if (!hovered) handleScrolling();
     }
 

--- a/textselect.cpp
+++ b/textselect.cpp
@@ -127,9 +127,8 @@ void TextSelect::handleMouseDown(const ImVec2& cursorPosStart) {
     ImVec2 mousePos = ImGui::GetMousePos() - cursorPosStart;
     std::size_t numLines = getNumLines();
 
-    // Get Y position of mouse cursor, in terms of line number (capped to the index of the last line)
-    std::size_t y = std::min(static_cast<std::size_t>(std::floor(mousePos.y / textHeight)), numLines - 1);
-    if (y < 0) return;
+    // Get Y position of mouse cursor, in terms of line number (clamped to the valid range)
+    std::size_t y = static_cast<std::size_t>(std::min(std::max(std::floor(mousePos.y / textHeight), 0.0f), static_cast<float>(numLines - 1)));
 
     std::string_view currentLine = getLineAtIdx(y);
     std::size_t x = getCharIndex(currentLine, mousePos.x);
@@ -299,8 +298,8 @@ void TextSelect::update() {
 
     // Handle mouse events
     if (ImGui::IsMouseDown(ImGuiMouseButton_Left)) {
-        if (hovered) handleMouseDown(cursorPosStart);
-        else handleScrolling();
+        handleMouseDown(cursorPosStart);
+        if (!hovered) handleScrolling();
     }
 
     drawSelection(cursorPosStart);

--- a/textselect.hpp
+++ b/textselect.hpp
@@ -44,6 +44,10 @@ class TextSelect {
     std::function<std::string_view(std::size_t)> getLineAtIdx; // Gets the string given a line number
     std::function<std::size_t()> getNumLines; // Gets the total number of lines
 
+    // Indicates whether selection should be updated. This is needed for distinguishing mouse drags that are
+    // initiated by clicking the text, or different element.
+    bool shouldHandleMouseDown = false;
+
     // Gets the user selection. Start and end are guaranteed to be in order.
     Selection getSelection() const;
 


### PR DESCRIPTION
Change behavoiur when cursor is outside window while selecting.

Previously selection would stop updating if cursor is not hovering the window.
This was annoying when trying to select whole lines and cursor was to the right or left or the window.

Now it is always updating.