### PR TITLE
Makes TextSelect aware of the Indent(20.0f) offset, so selection rectangles and mouse hit-testing now align with the indented text.

### DIFF
--- a/textselect.cpp
+++ b/textselect.cpp
@@ -468,6 +468,7 @@ void TextSelect::selectAll() {
 void TextSelect::update() {
     // ImGui::GetCursorStartPos() is in window coordinates so it is added to the window position
     ImVec2 cursorPosStart = ImGui::GetWindowPos() + ImGui::GetCursorStartPos();
+    cursorPosStart.x += ImGui::GetCurrentWindow()->DC.Indent.x;
 
     // Switch cursors if the window is hovered
     bool hovered = ImGui::IsWindowHovered();


### PR DESCRIPTION
TextSelect isn't aware of the "ImGui::Indent" function.

Before : 

![https://i.imgur.com/njJ3tCB.png](https://i.imgur.com/njJ3tCB.png)

After : 
![https://i.imgur.com/xPiKRRf.png](https://i.imgur.com/xPiKRRf.png)